### PR TITLE
Governance Board complete for 2022

### DIFF
--- a/governance/board.md
+++ b/governance/board.md
@@ -4,3 +4,6 @@
 
 * [Ringo De Smet](https://github.com/ringods)
 * [Simen A.W. Olsen](https://github.com/cobraz)
+* [Kathryn Morgan](https://github.com/usrbinkat)
+* [David Flanagan](https://github.com/rawkode)
+* [Paul Hicks](https://github.com/tenwit)


### PR DESCRIPTION
The Pulumiverse Governance Board is completed for 2022.

The following people stepped forward as candidate and were accepted during the first Pulumi Governance Board meeting, held on 14 March 2022:

* Kathryn Morgan
* David Flanagan
* Paul Hicks

Signed-off-by: Ringo De Smet <ringo@de-smet.name>