### PR TITLE
Use absolute URIs for all links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,22 +1,32 @@
 <img src="https://raw.githubusercontent.com/pulumiverse/.github/main/assets/github-logo.svg" width="300px" alt="Pulumiverse" />
 
-Welcome to the Pulumiverse. This a place for the Pulumi community to interact and collaborate on Pulumi-based libraries, projects, and learning resources. The idea was initiated by a [Reddit comment][reddit-comment].
+Welcome to the Pulumiverse. This a place for the Pulumi community to interact and collaborate on Pulumi-based 
+libraries, projects, and learning resources. The idea was initiated by a [Reddit comment][reddit-comment].
 
 ## Want to join the discussion?
 
-Create an [issue](https://github.com/pulumiverse/.github/issues), introduce what you want to bring to the Pulumiverse community – and off you go! 
+Create an [issue](https://github.com/pulumiverse/.github/issues), introduce what you want to bring to the 
+Pulumiverse community – and off you go! 
 You can reach us on the `#pulumiverse` channel of the [Pulumi Community Slack](https://slack.pulumi.com/).
 
 ## Motivation
 
-There are many libraries or collections of components for Pulumi out there. Most of them are made based on requirements of individual companies and developers. Pulumiverse aims to make a community where these libraries can be created, where opinionated configurations for Pulumi resources can be stored and discussed.
+There are many libraries or collections of components for Pulumi out there. Most of them are made based on 
+requirements of individual companies and developers. Pulumiverse aims to make a community where these 
+libraries can be created, where opinionated configurations for Pulumi resources can be stored and discussed.
 
 ## Community setup
 
-We defined the way of working for this community in the [Articles of Association](../governance/articles-of-association.md). Every year, we re-elect a new governance board, but at all times, you can see [who these board members are](../governance/board.md). This document is kept up to date after every election.
+We defined the way of working for this community in the 
+[Articles of Association](https://github.com/pulumiverse/.github/blob/main/governance/articles-of-association.md). 
+Every year, we re-elect a new governance board, but at all times, you can see 
+[who these board members are](https://github.com/pulumiverse/.github/blob/main/governance/board.md). 
+This document is kept up to date after every election.
 
 ## Contributors
 
-- Thanks [@annematilde](https://github.com/annematilde) for an awesome [logo](assets/logo.svg) and cool [mascot](assets/mascot.png).
+- Thanks [@annematilde](https://github.com/annematilde) for an awesome 
+  [logo](https://github.com/pulumiverse/.github/blob/main/assets/logo.svg) and cool 
+  [mascot](https://github.com/pulumiverse/.github/blob/main/assets/mascot.png).
 
 [reddit-comment]: https://www.reddit.com/r/kubernetes/comments/fqozeq/automating_deployments_to_kubernetes_with_pulumi/flsnysp/


### PR DESCRIPTION
We leverage the Github feature to show an organization wide README when browsing to the organziation URI:

https://github.com/pulumiverse

This document contains relative links and Github doesn't seem to generate the correct absolute URIs for these. If you click the links when going via the organization URI, some relative links work, some don't:

❌ `Articles of Association`
❌ `who these board members are`
🟢 `logo`
🟢  `mascot`
 
If you go to the file directly:

https://github.com/pulumiverse/.github/blob/main/profile/README.md

it is the other way around:

🟢 `Articles of Association`
🟢 `who these board members are`
❌ `logo`
❌ `mascot`

Hence, I replaced all the relative URIs with absolute URIs to have working links in the browser in both cases.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>