### PR TITLE
fix: step down as board member

### DIFF
--- a/governance/board.md
+++ b/governance/board.md
@@ -5,5 +5,4 @@
 * [Ringo De Smet](https://github.com/ringods)
 * [Simen A.W. Olsen](https://github.com/cobraz)
 * [Kathryn Morgan](https://github.com/usrbinkat)
-* [David Flanagan](https://github.com/rawkode)
 * [Paul Hicks](https://github.com/tenwit)


### PR DESCRIPTION
Due to Pulumi's decision to use guerilla marketing techniques to plaster HashiConf with their materials, I no longer wish to continue my role as a board member for the Pulumiverse