### PR TITLE
Assign issues & PRs to Pulumiverse board

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-@simenandre
-@ringods
-@dirien
-@usrbinkat
-@rebelopsio
+@pulumiverse/governance_board

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+@simenandre
+@ringods
+@dirien
+@usrbinkat
+@rebelopsio

--- a/.github/workflows/assign-issues.yaml
+++ b/.github/workflows/assign-issues.yaml
@@ -1,0 +1,17 @@
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: 'Auto-assign issue to Pulumiverse board'
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: simenandre,ringods,dirien,usrbinkat,rebelopsio


### PR DESCRIPTION
I added the Pulumiverse board as:

* the assignees for newly created issues (via a Github Actions workflow)
* the reviewers on Pull Requests (via CODEOWNERS file)

All of this to make triage of new issues/PRs more timely.