### PR TITLE
Annual Meeting 2024

### DIFF
--- a/governance/articles-of-association.md
+++ b/governance/articles-of-association.md
@@ -22,7 +22,7 @@ open a pull request).
 Pulumiverse has a board that consists of five board members. Board members hold
 their role for two years; voting is staggered as such:
 
-We elect the board leader and members #1 and #2 in term 1, who are elected for two years. In term 2, we
+We elect the board leader and members #1 and #2 in term 1. In term 2, we
 elect board members #3 and #4.
 
 Anyone (regardless of contributor or voting rights status) be can be nominated to become a board member, either by being nominated

--- a/governance/articles-of-association.md
+++ b/governance/articles-of-association.md
@@ -22,7 +22,7 @@ open a pull request).
 Pulumiverse has a board that consists of five board members. Board members hold
 their role for two years; voting is staggered as such:
 
-We elect board members 1 and 2 in year 1, elected for two years. In year 2, we
+We elect board members 1 and 2 in term 1, elected for two years. In term 2, we
 elect board members 3, 4 and 5. We elect board members 3, 4 and 5 for one year
 the first year.
 

--- a/governance/articles-of-association.md
+++ b/governance/articles-of-association.md
@@ -22,9 +22,9 @@ open a pull request).
 Pulumiverse has a board that consists of five board members. Board members hold
 their role for two years; voting is staggered as such:
 
-We elect the board leader and board members 1 and 2 in term 1, elected for two years. In term 2, we
-elect board members 3 and 4. We elect board members 3, 4 and 5 for one year
-the first year.
+We elect the board leader and members #1 and #2 in term 1, who are elected for two years. In term 2, we
+elect board members #3 and #4. We elect board members 3, 4, and 5 for one year
+in the first year.
 
 Anyone (regardless of contributor or voting rights status) be can be nominated to become a board member, either by being nominated
 by others or sending your nomination to current board members before the annual

--- a/governance/articles-of-association.md
+++ b/governance/articles-of-association.md
@@ -22,8 +22,8 @@ open a pull request).
 Pulumiverse has a board that consists of five board members. Board members hold
 their role for two years; voting is staggered as such:
 
-We elect board members 1 and 2 in term 1, elected for two years. In term 2, we
-elect board members 3, 4 and 5. We elect board members 3, 4 and 5 for one year
+We elect the board leader and board members 1 and 2 in term 1, elected for two years. In term 2, we
+elect board members 3 and 4. We elect board members 3, 4 and 5 for one year
 the first year.
 
 Anyone (regardless of contributor or voting rights status) be can be nominated to become a board member, either by being nominated

--- a/governance/articles-of-association.md
+++ b/governance/articles-of-association.md
@@ -23,8 +23,7 @@ Pulumiverse has a board that consists of five board members. Board members hold
 their role for two years; voting is staggered as such:
 
 We elect the board leader and members #1 and #2 in term 1, who are elected for two years. In term 2, we
-elect board members #3 and #4. We elect board members 3, 4, and 5 for one year
-in the first year.
+elect board members #3 and #4.
 
 Anyone (regardless of contributor or voting rights status) be can be nominated to become a board member, either by being nominated
 by others or sending your nomination to current board members before the annual

--- a/governance/board.md
+++ b/governance/board.md
@@ -9,14 +9,14 @@
 
 ## 2023
 
-* [Ringo De Smet](https://github.com/ringods)
-* [Simen A.W. Olsen](https://github.com/cobraz)
-* [Kathryn Morgan](https://github.com/usrbinkat)
-* [Stephen Morgan](https://www.linkedin.com/in/morgans/)
-* [Engin Diri](https://github.com/dirien)
+* Member #1 – [Ringo De Smet](https://github.com/ringods)
+* Member #2 – [Simen A.W. Olsen](https://github.com/cobraz)
+* Member #3 – [Kathryn Morgan](https://github.com/usrbinkat)
+* Member #4 – [Stephen Morgan](https://www.linkedin.com/in/morgans/)
+* Member #5 – [Engin Diri](https://github.com/dirien)
 
 ## 2024
 
-* [Simen A.W. Olsen](https://github.com/cobraz)
-* [Stephen Morgan](https://www.linkedin.com/in/morgans/)
-* [Thomas Meckel](https://github.com/tmeckel)
+* Leader – [Stephen Morgan](https://www.linkedin.com/in/morgans/)
+* Member #1 – [Simen A.W. Olsen](https://github.com/cobraz)
+* Member #2 – [Thomas Meckel](https://github.com/tmeckel)

--- a/governance/board.md
+++ b/governance/board.md
@@ -14,3 +14,9 @@
 * [Kathryn Morgan](https://github.com/usrbinkat)
 * [Stephen Morgan](https://www.linkedin.com/in/morgans/)
 * [Engin Diri](https://github.com/dirien)
+
+## 2023
+
+* [Simen A.W. Olsen](https://github.com/cobraz)
+* [Stephen Morgan](https://www.linkedin.com/in/morgans/)
+* [Thomas Meckel](https://github.com/tmeckel)

--- a/governance/board.md
+++ b/governance/board.md
@@ -15,7 +15,7 @@
 * [Stephen Morgan](https://www.linkedin.com/in/morgans/)
 * [Engin Diri](https://github.com/dirien)
 
-## 2023
+## 2024
 
 * [Simen A.W. Olsen](https://github.com/cobraz)
 * [Stephen Morgan](https://www.linkedin.com/in/morgans/)


### PR DESCRIPTION
The meeting was held on the 24th of January 2024 using Google Meet.

Attendees were:

- @tmeckel
- @simenandre 
- @rebelopsio

The meeting was opened by @simenandre, who shared some highlights from the previous years at Pulumiverse.
The main focus for Pulumiverse in the initial years has been to make it easier to bootstrap, maintain and build Pulumi providers. Thanks to the great work from the community, especially @ringods, we have become a community where it's easy and accessible to do just that. As a continuation, we have created a _Core Maintainers Group_ (#38), which we hope to do in the coming year will be more active.

The next point on the agenda was changes to policies. These policies are reflected in the changed files, most notably that we now have a board leader. The background for this change is that Pulumiverse needs someone who keeps tabs on our objectives, maintains our focus and regularly gets board members and core maintainers in a meeting to move our organization forward. We also changed from using _year_ to using _term_ in our bylaws for clarity.

It was voted that the board can substitute itself for members 3 and 4.

The following members were voted as board members:

- @rebelopsio as board leader for one year.
- @simenandre as board member 1 for two years.
- @tmeckel as board member 2 for two years.

Other notes:

- All attendees had voting rights.
- @rebelopsio still has one term left of his tenure.
